### PR TITLE
Refresh user settings on resume and display sync interval

### DIFF
--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/home/HomeScreen.kt
@@ -84,6 +84,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.byteutility.dev.leetcode.plus.R
@@ -127,6 +128,10 @@ fun HomeScreen(
     val dailyProblem by viewModel.dailyProblem.collectAsStateWithLifecycle()
     val dailyProblemSolved by viewModel.dailyProblemSolved.collectAsStateWithLifecycle()
     viewModel.startsSync(LocalContext.current)
+    LifecycleResumeEffect(Unit) {
+        viewModel.refreshUserSettings()
+        onPauseOrDispose {  }
+    }
     HomeLayout(
         uiState = uiState,
         dailyProblem = dailyProblem,
@@ -358,7 +363,7 @@ fun UserProfileContent(
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
-                        text = "Data updated every 30 min",
+                        text = "Data updated every ${uiState.syncInterval} min",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
                         fontSize = 12.sp

--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/home/HomeScreenViewModel.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/home/HomeScreenViewModel.kt
@@ -71,6 +71,9 @@ class UserDetailsViewModel @Inject constructor(
     private val userBasicInfo =
         MutableStateFlow(UserBasicInfo())
 
+    private val syncInterval =
+        MutableStateFlow<Long>(30)
+
     private val userContestInfo =
         MutableStateFlow(UserContestInfo())
 
@@ -99,7 +102,8 @@ class UserDetailsViewModel @Inject constructor(
                 userSubmissionState,
                 isWeeklyGoalSet,
                 videosByPlayListState,
-                _leetcodeUpcomingContestsState
+                _leetcodeUpcomingContestsState,
+                syncInterval
             )
         ) { values ->
             UserDetailsUiState(
@@ -109,7 +113,8 @@ class UserDetailsViewModel @Inject constructor(
                 userSubmissionState = values[3] as UserSubmissionState,
                 isWeeklyGoalSet = values[4] as Boolean,
                 videosByPlayListState = values[5] as VideosByPlayListState,
-                leetcodeUpcomingContestsState = values[6] as LeetcodeUpcomingContestsState
+                leetcodeUpcomingContestsState = values[6] as LeetcodeUpcomingContestsState,
+                syncInterval = values[7] as Long
             )
         }.stateIn(
             scope = viewModelScope,
@@ -128,6 +133,10 @@ class UserDetailsViewModel @Inject constructor(
                         userBasicInfo.value = it
                     }
                 }
+        }
+
+        viewModelScope.launch {
+            syncInterval.value = userDatastore.getSyncInterval()
         }
 
         viewModelScope.launch {
@@ -276,6 +285,12 @@ class UserDetailsViewModel @Inject constructor(
     fun startsSync(context: Context) {
         viewModelScope.launch {
             UserDetailsSyncWorker.enqueuePeriodicWork(context, userDatastore)
+        }
+    }
+
+    fun refreshUserSettings() {
+        viewModelScope.launch {
+            syncInterval.value = userDatastore.getSyncInterval()
         }
     }
 

--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/home/model/UserDetailsUiState.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/home/model/UserDetailsUiState.kt
@@ -16,6 +16,7 @@ data class UserDetailsUiState(
     val userProblemSolvedInfo: UserProblemSolvedInfo = UserProblemSolvedInfo(),
     val userSubmissionState: UserSubmissionState = UserSubmissionState(),
     val isWeeklyGoalSet: Boolean = false,
+    val syncInterval: Long = 30,
     val videosByPlayListState: VideosByPlayListState = VideosByPlayListState(),
     val leetcodeUpcomingContestsState: LeetcodeUpcomingContestsState = LeetcodeUpcomingContestsState()
 )


### PR DESCRIPTION
This commit introduces two main enhancements to the `HomeScreen`:

- User settings, specifically the sync interval, are now refreshed every time the screen resumes using `LifecycleResumeEffect`.
- The "Data updated every 30 min" text is now dynamic, displaying the actual sync interval fetched from user settings (e.g., "Data updated every 15 min").

To support this, `UserDetailsUiState` and `HomeScreenViewModel` have been updated to include and manage the `syncInterval` state.

Note: Instead of using `LifecycleResumeEffect`, we could expose the interval time in a flow, which may require introducing a new method or refactoring the existing one.