### PR TITLE
update to handle unnecessary sync when app startup.

### DIFF
--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/data/worker/ReminderNotificationWorker.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/data/worker/ReminderNotificationWorker.kt
@@ -41,7 +41,11 @@ class ReminderNotificationWorker @AssistedInject constructor(
 
         private const val REMINDER_NOTIFICATION_WORK = "reminder_notification_work"
 
-        suspend fun enqueuePeriodicWork(context: Context, userDatastore: UserDatastore) {
+        suspend fun enqueuePeriodicWork(
+            context: Context,
+            userDatastore: UserDatastore,
+            policy: ExistingPeriodicWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
+        ) {
             val notificationInterval = userDatastore.getNotificationInterval()
             val notificationRequest =
                 PeriodicWorkRequestBuilder<ReminderNotificationWorker>(
@@ -51,7 +55,7 @@ class ReminderNotificationWorker @AssistedInject constructor(
             WorkManager.getInstance(context)
                 .enqueueUniquePeriodicWork(
                     REMINDER_NOTIFICATION_WORK,
-                    ExistingPeriodicWorkPolicy.UPDATE,
+                    policy,
                     notificationRequest
                 )
         }

--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/data/worker/UserDetailsSyncWorker.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/data/worker/UserDetailsSyncWorker.kt
@@ -87,7 +87,11 @@ class UserDetailsSyncWorker @AssistedInject constructor(
     companion object {
         private const val WORK_NAME = "UserDetailsSyncWorker"
 
-        suspend fun enqueuePeriodicWork(context: Context, userDatastore: UserDatastore) {
+        suspend fun enqueuePeriodicWork(
+            context: Context,
+            userDatastore: UserDatastore,
+            policy: ExistingPeriodicWorkPolicy = ExistingPeriodicWorkPolicy.KEEP
+        ) {
             val syncInterval = userDatastore.getSyncInterval()
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -101,7 +105,7 @@ class UserDetailsSyncWorker @AssistedInject constructor(
             WorkManager.getInstance(context)
                 .enqueueUniquePeriodicWork(
                     WORK_NAME,
-                    ExistingPeriodicWorkPolicy.UPDATE,
+                    policy,
                     workRequest
                 )
         }

--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.byteutility.dev.leetcode.plus.ui.screens.settings
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.WorkManager
 import com.byteutility.dev.leetcode.plus.data.datastore.NotificationDataStore
 import com.byteutility.dev.leetcode.plus.data.datastore.UserDatastore
@@ -93,8 +94,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userDatastore.saveSyncInterval(minutes)
             _syncInterval.value = minutes
-            // Re-enqueue the worker with the new interval
-            UserDetailsSyncWorker.enqueuePeriodicWork(context, userDatastore)
+            UserDetailsSyncWorker.enqueuePeriodicWork(
+                context,
+                userDatastore,
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
+            )
         }
     }
 
@@ -102,7 +106,11 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             userDatastore.saveNotificationInterval(minutes)
             _notificationInterval.value = minutes
-            ReminderNotificationWorker.enqueuePeriodicWork(context, userDatastore)
+            ReminderNotificationWorker.enqueuePeriodicWork(
+                context,
+                userDatastore,
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE
+            )
         }
     }
 


### PR DESCRIPTION
  ✅ On app startup/login: Workers are enqueued with KEEP policy - won't trigger unnecessary executions

  ✅ When user changes sync/notification interval in settings: Workers are updated with CANCEL_AND_REENQUEUE policy - properly updates with new interval

  ✅ No more unnecessary worker executions on every app restart!