### PR TITLE
Center align 'Set a goal' text

### DIFF
--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/targetstatus/GoalProgressScreen.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/screens/targetstatus/GoalProgressScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -154,9 +155,12 @@ fun ProgressScreenContent(
                         "Set a goal to see your progress",
                         style = TextStyle(
                             color = Color.Gray,
-                            fontSize = 12.sp
+                            fontSize = 12.sp,
+                            textAlign = TextAlign.Center
                         ),
-                        modifier = Modifier.align(Alignment.Center),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .align(Alignment.Center),
                     )
                 }
             }


### PR DESCRIPTION
This commit centers the "Set a goal to see your progress" text within the `GoalProgressScreen` by applying `fillMaxWidth()` and `TextAlign.Center`.

Solves https://github.com/nur-shuvo/LeetcodePlus/issues/56