### PR TITLE
Fix code editor crash when selecting language without registered grammar

### DIFF
--- a/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/codeEditSubmit/config/EditorLanguageHelper.kt
+++ b/app/src/main/kotlin/com/byteutility/dev/leetcode/plus/ui/codeEditSubmit/config/EditorLanguageHelper.kt
@@ -13,6 +13,7 @@ import io.github.rosemoe.sora.widget.CodeEditor
 object EditorLanguageHelper {
 
     private const val TAG = "EditorLanguageHelper"
+    private const val FALLBACK_SCOPE = "source.java"
 
     /**
      * Configures the CodeEditor with language-specific settings including
@@ -22,6 +23,7 @@ object EditorLanguageHelper {
      * @param languageSlug LeetCode language slug (e.g., "python3", "java")
      * @return true if configuration succeeded, false otherwise
      */
+
     fun configureEditor(editor: CodeEditor, languageSlug: String): Boolean {
         return try {
             // 1. Get TextMate scope name from language mapper
@@ -32,8 +34,14 @@ object EditorLanguageHelper {
             val colorScheme = TextMateColorScheme.create(ThemeRegistry.getInstance())
             editor.colorScheme = colorScheme
 
-            // 3. Create TextMate language with auto-completion enabled
-            val language = TextMateLanguage.create(scopeName, true)
+            // 3. Create TextMate language with auto-completion enabled,
+            //    falling back to Java if the grammar isn't registered
+            val language = try {
+                TextMateLanguage.create(scopeName, true)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Grammar not registered for scope: $scopeName, falling back to Java", e)
+                TextMateLanguage.create(FALLBACK_SCOPE, true)
+            }
 
             // 4. Set the language on editor
             editor.setEditorLanguage(language)


### PR DESCRIPTION
## Summary

Fixes a crash in the code editor when selecting a language that doesn't have a TextMate grammar registered.

## Root cause

`LanguageMapper` maps 20+ LeetCode language slugs to TextMate scope names (Ruby, PHP, Swift, SQL, Shell, Scala, Dart, Elixir, Erlang, Racket, etc.), but `languages.json` only registers grammars for 10 languages (Python, Java, JavaScript, TypeScript, C, C++, Kotlin, C#, Go, Rust).

When a user selects an unregistered language like Ruby:
1. `LanguageMapper.getTextMateScopeName("ruby")` returns `"source.ruby"`
2. `TextMateLanguage.create("source.ruby", true)` throws `IllegalArgumentException` because the grammar isn't in the registry
3. The exception is caught by the outer `try/catch`, but the editor is left with just a color scheme and no language — partially configured

## Fix

Added a targeted `catch (IllegalArgumentException)` around the `TextMateLanguage.create()` call that falls back to Java syntax highlighting (`source.java`) when the requested grammar isn't registered. This way the editor always gets a working language configuration instead of being left in a broken state.

## Alternative approaches considered

- **Adding all missing grammar files**: Would be the ideal fix but requires sourcing and bundling 10+ additional `.tmLanguage.json` files, significantly increasing APK size
- **Filtering the language selection list**: Would hide valid LeetCode languages from users, reducing functionality

The fallback approach is the least invasive and still gives users syntax highlighting (Java is close enough for most C-style languages).

Fixes #68